### PR TITLE
Remove refmaps

### DIFF
--- a/src/main/resources/create_dragons_plus.mixins.json
+++ b/src/main/resources/create_dragons_plus.mixins.json
@@ -3,7 +3,6 @@
   "package": "plus.dragons.createdragonsplus.mixin",
   "plugin": "plus.dragons.createdragonsplus.mixin.CDPMixinConfigPlugin",
   "compatibilityLevel": "JAVA_21",
-  "refmap": "create_dragons_plus.refmap.json",
   "mixins": [
     "create.AirCurrentMixin",
     "create.AirCurrentMixin$AirCurrentSegmentMixin",


### PR DESCRIPTION
NeoForge don't need refmaps and it only causes warning in the logs.