### PR TITLE
Fixed the missing info on potion input of Dragon Breath Fluid Recipe

### DIFF
--- a/src/main/java/plus/dragons/createdragonsplus/mixin/create/PotionMixingRecipesMixin.java
+++ b/src/main/java/plus/dragons/createdragonsplus/mixin/create/PotionMixingRecipesMixin.java
@@ -37,6 +37,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.crafting.DataComponentFluidIngredient;
 import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -64,7 +65,10 @@ public class PotionMixingRecipesMixin {
                 var recipeId = CDPCommon.asResource(id + "_using_dragon_breath_fluid");
                 var recipe = new StandardProcessingRecipe.Builder<>(MixingRecipe::new, recipeId)
                         .require(CDPFluids.COMMON_TAGS.dragonBreath, 250)
-                        .require(SizedFluidIngredient.of(fromFluid))
+                        .require(new SizedFluidIngredient(
+                                DataComponentFluidIngredient.of(false, fromFluid),
+                                fromFluid.getAmount()
+                        ))
                         .output(toFluid)
                         .requiresHeat(HeatCondition.HEATED)
                         .build();


### PR DESCRIPTION
before: 
<img width="357" height="212" alt="image" src="https://github.com/user-attachments/assets/d10ad4e5-b649-4614-ad28-4d58b6bf1026" />
fixed: 
<img width="360" height="207" alt="image" src="https://github.com/user-attachments/assets/563cec58-7436-4351-87a0-3b75856ca479" />

Just like the implement of Create: 
https://github.com/Creators-of-Create/Create/blob/fdfde66c337e3ae36b260459c3b52802c58630f6/src/main/java/com/simibubi/create/content/fluids/potion/PotionMixingRecipes.java#L149-L159