### PR TITLE
Fix several mixin remap issues in Forge 1.20.1 port

### DIFF
--- a/src/main/java/plus/dragons/createdragonsplus/mixin/create/AirFlowParticleMixin.java
+++ b/src/main/java/plus/dragons/createdragonsplus/mixin/create/AirFlowParticleMixin.java
@@ -33,15 +33,29 @@ import org.spongepowered.asm.mixin.injection.At;
 import plus.dragons.createdragonsplus.common.kinetics.fan.AirCurrentAccess;
 import plus.dragons.createdragonsplus.common.kinetics.fan.DynamicParticleFanProcessingType;
 
-@Mixin(value = AirFlowParticle.class, remap = false)
+@Mixin(AirFlowParticle.class)
 public class AirFlowParticleMixin {
-    @Shadow
+
+    @Shadow(remap = false)
     @Final
     private IAirCurrentSource source;
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @WrapOperation(method = "tick", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/kinetics/fan/processing/FanProcessingType;morphAirFlow(Lcom/simibubi/create/content/kinetics/fan/processing/FanProcessingType$AirFlowParticleAccess;Lnet/minecraft/util/RandomSource;)V"))
-    private void tick$morphAirFlowWithParticleData(FanProcessingType type, AirFlowParticleAccess particleAccess, RandomSource random, Operation<Void> original, @Local(name = "distance") double distance) {
+    @WrapOperation(
+        method = "tick",
+        at = @At(
+            value = "INVOKE",
+            target = "Lcom/simibubi/create/content/kinetics/fan/processing/FanProcessingType;morphAirFlow(Lcom/simibubi/create/content/kinetics/fan/processing/FanProcessingType$AirFlowParticleAccess;Lnet/minecraft/util/RandomSource;)V",
+            remap = false
+        )
+    )
+    private void tick$morphAirFlowWithParticleData(
+        FanProcessingType type,
+        AirFlowParticleAccess particleAccess,
+        RandomSource random,
+        Operation<Void> original,
+        @Local(name = "distance") double distance
+    ) {
         if (type instanceof DynamicParticleFanProcessingType dynamicType) {
             AirCurrentAccess airCurrent = (AirCurrentAccess) this.source.getAirCurrent();
             Object particleData;

--- a/src/main/java/plus/dragons/createdragonsplus/mixin/create/ContraptionMixin.java
+++ b/src/main/java/plus/dragons/createdragonsplus/mixin/create/ContraptionMixin.java
@@ -36,7 +36,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import plus.dragons.createdragonsplus.common.fluids.WaterAndLavaLoggedBlock;
 
-@Mixin(value = Contraption.class, remap = false)
+@Mixin(value = Contraption.class)
 public abstract class ContraptionMixin {
     @Inject(method = "removeBlocksFromWorld", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;I)Z", shift = At.Shift.AFTER))
     private void removeBlocksFromWorld$fixRemoveBlockLeaveNoFluid(Level world, BlockPos offset, CallbackInfo ci, @Local Block blockIn, @Local BlockState oldState, @Local(ordinal = 1) BlockPos add) {

--- a/src/main/java/plus/dragons/createdragonsplus/mixin/create/OpenEndedPipeMixin.java
+++ b/src/main/java/plus/dragons/createdragonsplus/mixin/create/OpenEndedPipeMixin.java
@@ -42,32 +42,52 @@ public class OpenEndedPipeMixin {
     @Shadow
     private BlockPos outputPos;
 
-    @Inject(method = "provideFluidToSpace", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/dimension/DimensionType;ultraWarm()Z"), cancellable = true)
-    private void provideFluidToSpace$checkVaporize(FluidStack fluid, boolean simulate, CallbackInfoReturnable<Boolean> cir) {
+    @Inject(method = "provideFluidToSpace", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/dimension/DimensionType;ultraWarm()Z", remap = true), cancellable = true)
+    private void provideFluidToSpace$checkVaporize(
+            FluidStack fluid,
+            boolean simulate,
+            CallbackInfoReturnable<Boolean> cir) {
         var type = fluid.getFluid().getFluidType();
-        if (world.dimensionType().ultraWarm() && type.isVaporizedOnPlacement(world, outputPos, fluid)) {
+
+        if (world.dimensionType().ultraWarm()
+                && type.isVaporizedOnPlacement(world, outputPos, fluid)) {
             type.onVaporize(null, world, outputPos, fluid);
             cir.setReturnValue(true);
         }
     }
 
-    @Inject(method = "provideFluidToSpace", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/fluids/FluidReactions;handlePipeSpillCollision(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/material/Fluid;Lnet/minecraft/world/level/material/FluidState;)V"), cancellable = true)
-    private void provideFluidToSpace$handleDyeLavaCollision(FluidStack fluid, boolean simulate, CallbackInfoReturnable<Boolean> cir, @Local FluidState fluidState) {
+    @Inject(method = "provideFluidToSpace", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/fluids/FluidReactions;"
+            + "handlePipeSpillCollision("
+            + "Lnet/minecraft/world/level/Level;"
+            + "Lnet/minecraft/core/BlockPos;"
+            + "Lnet/minecraft/world/level/material/Fluid;"
+            + "Lnet/minecraft/world/level/material/FluidState;)V"), cancellable = true)
+    private void provideFluidToSpace$handleDyeLavaCollision(
+            FluidStack fluid,
+            boolean simulate,
+            CallbackInfoReturnable<Boolean> cir,
+            @Local FluidState fluidState) {
         BlockState result = null;
+
         var pipeType = fluid.getFluid().getFluidType();
         var worldType = fluidState.getFluidType();
+
         if (pipeType == ForgeMod.LAVA_TYPE.get()) {
             result = CDPFluids.Reactions.getDyeLavaInteraction(worldType);
         } else if (worldType == ForgeMod.LAVA_TYPE.get()) {
             result = CDPFluids.Reactions.getDyeLavaInteraction(pipeType);
         }
+
         if (result == null)
             return;
+
         if (!simulate) {
-            var placed = ForgeEventFactory.fireFluidPlaceBlockEvent(world, outputPos, outputPos, result);
+            var placed = ForgeEventFactory.fireFluidPlaceBlockEvent(
+                    world, outputPos, outputPos, result);
             world.setBlockAndUpdate(outputPos, placed);
             world.levelEvent(1501, outputPos, 0);
         }
+
         cir.setReturnValue(true);
     }
 }


### PR DESCRIPTION
Fix #107 
Several mixins in the 1.20.1 port were using `remap = false` on Create classes while still targeting Minecraft mapped members.

This worked in the development environment because named mappings were available, but failed in the production Forge environment where SRG mappings are used.

Fixed affected mixins by keeping `remap = false` for Create/third-party members while enabling remapping only for Minecraft targets.

Affected mixins:
- ContraptionMixin
- AirFlowParticleMixin
- OpenEndedPipeMixin

Testing:
- Forge 1.20.1 release environment
- Create 6.0.8
- Clean instance without other Create addons
- Verified entering world and affected functionality works correctly